### PR TITLE
Make tooltip itself unhoverable

### DIFF
--- a/CSS Tooltip/styles.css
+++ b/CSS Tooltip/styles.css
@@ -40,6 +40,7 @@ form input{
     left: 50%;
     opacity: 0;
     transition: all ease 0.3s;
+    pointer-events: none;
 }
 
 .tooltip::before{


### PR DESCRIPTION
Without setting `pointer-events` to `none`, the tooltip itself is hoverable, meaning that if you hover in the area where the tooltip is, it'll become visible.